### PR TITLE
Support for DNS names that both have A and AAAA records.

### DIFF
--- a/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/future/LdapNetworkConnectionFuture.java
+++ b/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/future/LdapNetworkConnectionFuture.java
@@ -1,0 +1,33 @@
+package org.apache.directory.ldap.client.api.future;
+
+import org.apache.mina.core.future.ConnectFuture;
+import org.apache.mina.core.service.IoConnector;
+
+/**
+ * Data class containing future LDAP connection results.
+ */
+public class LdapNetworkConnectionFuture
+{
+    private IoConnector connector;
+    private ConnectFuture connectFuture;
+
+    public ConnectFuture getConnectFuture()
+    {
+        return connectFuture;
+    }
+
+    public void setConnectFuture( ConnectFuture connectFuture )
+    {
+        this.connectFuture = connectFuture;
+    }
+
+    public IoConnector getConnector()
+    {
+        return connector;
+    }
+
+    public void setConnector( IoConnector connector )
+    {
+        this.connector = connector;
+    }
+}


### PR DESCRIPTION
We were having an issue that I could describe like this.

We were running IPv6 tests in an IPv6 only environment. The DNS name for
the test ldap server had both IPv4 and IPv6 records (A and AAAA
respectively).
The LDAP client only tried to connect to the first DNS record retrieved,
which in our case was always the IPv4 address.
This caused all our LDAP connections to fail.

This patch lists all A and AAAA records for a DNS name and tries to
connect to them simultaneously. The first socket that succeeds is used
and the others are dropped.

I do realize this might have a bit of performance penalty. However, the
library is designed to reuse connections so I hope this change will be
much more of a benefit than a bottleneck.
